### PR TITLE
Added missing go server

### DIFF
--- a/.cli.json
+++ b/.cli.json
@@ -5,7 +5,7 @@
     {
       "name": "main",
       "clients": ["web"],
-      "servers": ["java", "node", "php", "python", "ruby"]
+      "servers": ["java", "node", "php", "python", "ruby", "go"]
     }
   ]
 }

--- a/server/README.md
+++ b/server/README.md
@@ -10,3 +10,4 @@ Pick the language you are most comfortable in and follow the instructions in the
 * [Ruby (Sinatra)](ruby/README.md)
 * [PHP (Slim)](php/README.md)
 * [Java (Spark)](java/README.md)
+* [Golang](go/README.md)


### PR DESCRIPTION
Added go server to .cli.json

Looks like the `stripe samples create connect-onboarding-for-standard` uses `.cli.json` - ref https://github.com/stripe/stripe-cli/blob/bdd91b91279def288fc6fa26857c4eacf407ac70/pkg/samples/samples.go#L170