### PR TITLE
Add reminders about security best practices and redact secrets in logs

### DIFF
--- a/server/dotnet/Program.cs
+++ b/server/dotnet/Program.cs
@@ -23,6 +23,11 @@ app.UseStaticFiles(new StaticFileOptions
 });
 
 DotNetEnv.Env.Load();
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 StripeConfiguration.ApiKey = Environment.GetEnvironmentVariable("STRIPE_SECRET_KEY");
 
 app.MapGet("/", () =>

--- a/server/go/server.go
+++ b/server/go/server.go
@@ -21,6 +21,11 @@ func main() {
 		log.Fatal("Error loading .env file")
 	}
 
+	// Don't put any keys in code. Use an environment variable (as shown
+	// here) or secrets vault to supply keys to your integration.
+	//
+	// See https://docs.stripe.com/keys-best-practices and find your
+	// keys at https://dashboard.stripe.com/apikeys.
 	stripe.Key = os.Getenv("STRIPE_SECRET_KEY")
 
 	// For sample support and debugging, not required for production:

--- a/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/server/java/src/main/java/com/stripe/sample/Server.java
@@ -24,6 +24,11 @@ public class Server {
     public static void main(String[] args) {
         port(4242);
         Dotenv dotenv = Dotenv.load();
+        // Don't put any keys in code. Use an environment variable (as shown
+        // here) or secrets vault to supply keys to your integration.
+        //
+        // See https://docs.stripe.com/keys-best-practices and find your
+        // keys at https://dashboard.stripe.com/apikeys.
         Stripe.apiKey = dotenv.get("STRIPE_SECRET_KEY");
         // For sample support and debugging, not required for production:
         Stripe.setAppInfo(

--- a/server/nextjs/lib/stripe.ts
+++ b/server/nextjs/lib/stripe.ts
@@ -1,5 +1,10 @@
 import Stripe from "stripe";
 
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: "2025-12-15.clover",
   appInfo: {

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -8,6 +8,11 @@ const session = require("express-session");
 const app = express();
 const port = process.env.PORT || 4242;
 
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY, {
   apiVersion: '2020-08-27',
   appInfo: { // For sample support and debugging, not required for production:

--- a/server/php/public/shared.php
+++ b/server/php/public/shared.php
@@ -9,11 +9,11 @@ if(!file_exists('../.env')) {
   ?>
   <p>Make a copy of <code>.env.example</code>, place it in the same directory as composer.json, and name it <code>.env</code>, then populate the variables.</p>
   <p>It should look something like the following, but contain your <a href='https://dashboard.stripe.com/test/apikeys'>API keys</a>:</p>
-  <pre># Don't put any keys in code. Use an environment variable (as shown
-# here) or secrets vault to supply keys to your integration.
-#
-# See https://docs.stripe.com/keys-best-practices and find your
-# keys at https://dashboard.stripe.com/apikeys.</pre>
+  <pre>Don't put any keys in code. Use an environment variable (as shown
+here) or secrets vault to supply keys to your integration.
+
+See https://docs.stripe.com/keys-best-practices and find your
+keys at https://dashboard.stripe.com/apikeys.</pre>
   <pre>STRIPE_SECRET_KEY=sk_test...</pre>
   <hr>
 

--- a/server/php/public/shared.php
+++ b/server/php/public/shared.php
@@ -9,6 +9,11 @@ if(!file_exists('../.env')) {
   ?>
   <p>Make a copy of <code>.env.example</code>, place it in the same directory as composer.json, and name it <code>.env</code>, then populate the variables.</p>
   <p>It should look something like the following, but contain your <a href='https://dashboard.stripe.com/test/apikeys'>API keys</a>:</p>
+  # Don't put any keys in code. Use an environment variable (as shown
+  # here) or secrets vault to supply keys to your integration.
+  #
+  # See https://docs.stripe.com/keys-best-practices and find your
+  # keys at https://dashboard.stripe.com/apikeys.
   <pre>STRIPE_SECRET_KEY=sk_test...</pre>
   <hr>
 

--- a/server/php/public/shared.php
+++ b/server/php/public/shared.php
@@ -9,11 +9,11 @@ if(!file_exists('../.env')) {
   ?>
   <p>Make a copy of <code>.env.example</code>, place it in the same directory as composer.json, and name it <code>.env</code>, then populate the variables.</p>
   <p>It should look something like the following, but contain your <a href='https://dashboard.stripe.com/test/apikeys'>API keys</a>:</p>
-  # Don't put any keys in code. Use an environment variable (as shown
-  # here) or secrets vault to supply keys to your integration.
-  #
-  # See https://docs.stripe.com/keys-best-practices and find your
-  # keys at https://dashboard.stripe.com/apikeys.
+  <pre># Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.</pre>
   <pre>STRIPE_SECRET_KEY=sk_test...</pre>
   <hr>
 

--- a/server/python/server.py
+++ b/server/python/server.py
@@ -22,6 +22,11 @@ stripe.set_app_info(
     version='0.0.1',
     url='https://github.com/stripe-samples')
 
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 stripe.api_key = os.getenv('STRIPE_SECRET_KEY')
 stripe.api_version = os.getenv('STRIPE_API_VERSION', '2020-08-27')
 

--- a/server/ruby/server.rb
+++ b/server/ruby/server.rb
@@ -13,6 +13,11 @@ Stripe.set_app_info(
   url: 'https://github.com/stripe-samples'
 )
 Stripe.api_version = '2020-08-27'
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 
 enable :sessions

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,6 +107,11 @@ end
 
 SERVER_URL = ENV.fetch('SERVER_URL', 'http://localhost:4242')
 Dotenv.load
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 Stripe.max_network_retries = 2
 Stripe.api_version = "2020-08-27"


### PR DESCRIPTION
## Summary

- Adds comments before `STRIPE_SECRET_KEY` assignments in all server files urging users not to put keys in code and pointing to [https://docs.stripe.com/keys-best-practices](https://docs.stripe.com/keys-best-practices).
